### PR TITLE
Set default dark theme & unify auth routes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *));
 @theme inline {
   /* Colors from Chumme v3 (Pink-toned) */
   --color-brand-core: var(--brand-core);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
       >
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
         >

--- a/app/onboarding/welcome/page.tsx
+++ b/app/onboarding/welcome/page.tsx
@@ -1,25 +1,11 @@
 "use client";
-import { RoleSelection } from "@/modules/auth/components/RoleSelection";
-import { AuthLayout } from "@/modules/auth/components/AuthLayout";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function WelcomePage() {
   const router = useRouter();
-
-  const handleSelectRole = (role: "admin" | "user") => {
-    if (role === "admin") {
-      router.push("/auth?role=admin");
-    } else {
-      router.push("/auth?role=user");
-    }
-  };
-
-  return (
-    <AuthLayout>
-      <RoleSelection
-        onSelectRole={handleSelectRole}
-        onSignIn={() => router.push("/auth")}
-      />
-    </AuthLayout>
-  );
+  useEffect(() => {
+    router.replace("/auth");
+  }, [router]);
+  return null;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,7 +66,7 @@ export default function LandingPage() {
               </button>
 
               <button
-                onClick={() => router.push('/register')}
+                onClick={() => router.push('/auth')}
                 className="bg-gradient-to-r from-[#A53860] to-[#670D2F] hover:opacity-90 text-white font-medium px-6 py-2 rounded-lg transition-all"
               >
                 Get Started
@@ -112,7 +112,7 @@ export default function LandingPage() {
                 className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16"
               >
                 <button
-                  onClick={() => router.push('/register')}
+                  onClick={() => router.push('/auth')}
                   className="bg-gradient-to-r from-[#A53860] to-[#670D2F] hover:opacity-90 text-white font-medium text-base px-10 py-4 rounded-xl transition-all"
                 >
                   Start Your Journey
@@ -304,7 +304,7 @@ export default function LandingPage() {
                 {/* whileHover scales button up to 105%, whileTap scales down to 95% */}
                 <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                   <button
-                    onClick={() => router.push('/register')}
+                    onClick={() => router.push('/auth')}
                     className="bg-gradient-to-r from-[#A53860] to-[#670D2F] hover:from-[#EF88AD] hover:to-[#A53860] text-white font-medium text-lg px-12 py-5 rounded-xl transition-all shadow-2xl shadow-[#A53860]/40"
                   >
                     Start Your Journey

--- a/modules/auth/components/AuthCard.tsx
+++ b/modules/auth/components/AuthCard.tsx
@@ -3,16 +3,18 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/modules/shared/utils";
+import { useTheme } from "next-themes";
 
 export function AuthCard({
   children,
   className,
-  tone = "auto",
 }: {
   children: React.ReactNode;
   className?: string;
-  tone?: "auto" | "light";
 }) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 18 }}
@@ -20,7 +22,10 @@ export function AuthCard({
       exit={{ opacity: 0, y: -18 }}
       transition={{ duration: 0.35 }}
       className={cn(
-        "w-full lg:w-[480px] rounded-2xl shadow-lg border p-10 bg-white border-gray-200 dark:bg-gray-900 dark:border-gray-800",
+        "w-full lg:w-[480px] rounded-2xl shadow-lg border p-10",
+        isDark
+          ? "bg-gray-900 border-gray-800"
+          : "bg-white border-gray-200",
         className,
       )}
     >

--- a/modules/auth/components/AuthLayout.tsx
+++ b/modules/auth/components/AuthLayout.tsx
@@ -7,6 +7,9 @@ import { motion } from "framer-motion";
 import { ChevronDown, Globe } from "lucide-react";
 import { cn } from "@/modules/shared/utils";
 
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
 interface AuthLayoutProps {
   children: React.ReactNode;
   headline?: string[];
@@ -20,6 +23,10 @@ export function AuthLayout({
   tagline = "Connect with fans around the world and share your passion in a vibrant community",
   className,
 }: AuthLayoutProps) {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const isDark = mounted ? resolvedTheme === "dark" : true;
 
   return (
     <div
@@ -27,7 +34,10 @@ export function AuthLayout({
     >
       <div
         className={cn(
-          "absolute inset-0 transition-all duration-300 bg-gradient-to-br from-[#fce7f3] via-[#fce1ed] to-[#e9d5fd] dark:from-[#1a0510] dark:via-[#0a0a0a] dark:to-[#1a0510]",
+          "absolute inset-0 transition-all duration-300 bg-gradient-to-br",
+          isDark
+            ? "from-[#1a0510] via-[#0a0a0a] to-[#1a0510]"
+            : "from-[#fce7f3] via-[#fce1ed] to-[#e9d5fd]"
         )}
       />
 
@@ -113,7 +123,10 @@ export function AuthLayout({
             animate={{ y: 0, opacity: 1 }}
             transition={{ delay: 0.4, duration: 0.6 }}
           >
-            <h1 className="font-['Poppins',sans-serif] text-5xl xl:text-6xl font-bold mb-5 leading-tight text-gray-900 dark:text-white">
+            <h1 className={cn(
+              "font-['Poppins',sans-serif] text-5xl xl:text-6xl font-bold mb-5 leading-tight",
+              isDark ? "text-white" : "text-gray-900"
+            )}>
               {headline.map((line, i) => (
                 <span key={i}>
                   {line}
@@ -121,7 +134,10 @@ export function AuthLayout({
                 </span>
               ))}
             </h1>
-            <p className="font-['Poppins',sans-serif] text-lg leading-relaxed max-w-md text-gray-600 dark:text-gray-400">
+            <p className={cn(
+              "font-['Poppins',sans-serif] text-lg leading-relaxed max-w-md",
+              isDark ? "text-gray-400" : "text-gray-600"
+            )}>
               {tagline}
             </p>
           </motion.div>
@@ -135,7 +151,10 @@ export function AuthLayout({
             <button
               type="button"
               className={cn(
-                "flex items-center gap-2 transition-colors text-gray-700 hover:text-[#A53860] dark:text-gray-400 dark:hover:text-[#EF88AD]",
+                "flex items-center gap-2 transition-colors",
+                isDark
+                  ? "text-gray-400 hover:text-[#EF88AD]"
+                  : "text-gray-700 hover:text-[#A53860]"
               )}
             >
               <Globe className="w-5 h-5" />

--- a/modules/auth/components/ForgotPasswordForm.tsx
+++ b/modules/auth/components/ForgotPasswordForm.tsx
@@ -26,7 +26,7 @@ export function ForgotPasswordForm() {
         exit={{ opacity: 0, y: -20 }}
         transition={{ duration: 0.4 }}
       >
-        <AuthCard tone="light">
+        <AuthCard>
           <button
             type="button"
             onClick={() => router.push("/auth")}

--- a/modules/auth/components/LoginForm.tsx
+++ b/modules/auth/components/LoginForm.tsx
@@ -65,20 +65,18 @@ export function LoginForm() {
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.4 }}
         >
-          <AuthCard tone="auto">
+          <AuthCard>
             <div className="mb-8 flex items-start justify-between">
               <div className="flex-1">
                 <h2
-                  className={`text-2xl font-bold mb-2 ${
-                    isDarkMode ? "text-white" : "text-gray-900"
-                  }`}
+                  className={`text-2xl font-bold mb-2 ${isDarkMode ? "text-white" : "text-gray-900"
+                    }`}
                 >
                   Sign In
                 </h2>
                 <p
-                  className={`text-sm ${
-                    isDarkMode ? "text-gray-400" : "text-gray-600"
-                  }`}
+                  className={`text-sm ${isDarkMode ? "text-gray-400" : "text-gray-600"
+                    }`}
                 >
                   Welcome back! Please enter your details
                 </p>
@@ -86,11 +84,10 @@ export function LoginForm() {
               <button
                 type="button"
                 onClick={toggleTheme}
-                className={`p-2 rounded-lg transition-all ${
-                  isDarkMode
+                className={`p-2 rounded-lg transition-all ${isDarkMode
                     ? "bg-gray-800 text-gray-300 hover:bg-gray-700"
                     : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
+                  }`}
                 title={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
               >
                 {mounted ? (
@@ -250,7 +247,7 @@ export function LoginForm() {
                   Don&apos;t have an account?{" "}
                   <button
                     type="button"
-                    onClick={() => router.push("/onboarding/welcome")}
+                    onClick={() => router.push("/register")}
                     className="text-[#A53860] hover:text-[#670D2F] font-semibold transition-colors"
                   >
                     Sign Up

--- a/modules/auth/components/RegisterForm.tsx
+++ b/modules/auth/components/RegisterForm.tsx
@@ -80,7 +80,7 @@ export function RegisterForm() {
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.4 }}
         >
-          <AuthCard tone="light">
+          <AuthCard>
             <button
               type="button"
               onClick={() => router.push("/auth")}

--- a/modules/auth/components/VerifyEmailForm.tsx
+++ b/modules/auth/components/VerifyEmailForm.tsx
@@ -91,7 +91,7 @@ export function VerifyEmailForm() {
         exit={{ opacity: 0, y: -20 }}
         transition={{ duration: 0.4 }}
       >
-        <AuthCard tone="light">
+        <AuthCard>
           <button
             type="button"
             onClick={() => router.push(`/register?email=${encodeURIComponent(email)}`)}

--- a/modules/dashboard/components/DiscoverPage.tsx
+++ b/modules/dashboard/components/DiscoverPage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { motion } from "framer-motion";
 import { useState } from "react";
 import {


### PR DESCRIPTION
Set the app default theme to dark and add a custom dark variant in globals.css. Update auth components to rely on next-themes (AuthCard/AuthLayout) instead of a tone prop and apply conditional styles based on resolvedTheme. Unify entry points to the auth flows by routing various buttons to /auth (landing page buttons, forgot/register/verify flows) and change the onboarding welcome page to immediately redirect to /auth. Minor fixes: adjust LoginForm sign-up link to /register and mark DiscoverPage as client-side with "use client".