### PR TITLE
Add music service & revamp Music/Karaoke UIs

### DIFF
--- a/app/dashboard/music/karaoke/page.tsx
+++ b/app/dashboard/music/karaoke/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useState, useEffect } from "react";
+import { KaraokePage } from "@/modules/collaboration/components/KaraokePage";
+
+const KaraokePageRoute = () => {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  const isDark = mounted ? resolvedTheme === "dark" : true;
+  return <KaraokePage isDark={isDark} />;
+};
+
+export default KaraokePageRoute;

--- a/app/dashboard/music/song/page.tsx
+++ b/app/dashboard/music/song/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useState, useEffect } from "react";
+import { MusicPage } from "@/modules/collaboration/components/MusicPage";
+
+const SongPageRoute = () => {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  const isDark = mounted ? resolvedTheme === "dark" : true;
+  return <MusicPage isDark={isDark} />;
+};
+
+export default SongPageRoute;

--- a/modules/collaboration/api/music.service.ts
+++ b/modules/collaboration/api/music.service.ts
@@ -1,0 +1,115 @@
+import { api } from "@/modules/shared/api/api-client";
+
+export interface MusicTrack {
+  id: string;
+  title: string;
+  duration?: number;
+  bpm?: number;
+  isKaraoke: boolean;
+  release_date: string;
+  createdAt: string;
+  musicArtist?: { id: string; name: string; imageUrl?: string };
+  musicAlbum?: { id: string; album: string; genre: string };
+  musicFile?: { id: string; fileUrl: string; fileType: string };
+  status?: string;
+}
+
+export interface MusicListResponse {
+  data: MusicTrack[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export interface ArtistOption {
+  id: string;
+  name: string;
+  imageUrl?: string | null;
+}
+
+export interface ArtistsResponse {
+  success: boolean;
+  data: ArtistOption[];
+}
+
+export const musicService = {
+  getSongs: async (params?: {
+    page?: number;
+    limit?: number;
+    search?: string;
+    isKaraoke?: boolean;
+  }): Promise<MusicListResponse> => {
+    const query = new URLSearchParams();
+    if (params?.page)     query.set("page",      String(params.page));
+    if (params?.limit)    query.set("limit",     String(params.limit));
+    if (params?.search)   query.set("search",    params.search);
+    if (params?.isKaraoke !== undefined)
+      query.set("isKaraoke", String(params.isKaraoke));
+
+    const res = await api.get<MusicListResponse>(
+      `/api/v1/music/list?${query.toString()}`,
+    );
+    if (!res.ok)
+      throw new Error(
+        (res.data as any)?.message || "Failed to fetch music",
+      );
+    return res.data!;
+  },
+
+  getArtists: async (): Promise<ArtistOption[]> => {
+    const res = await api.get<ArtistsResponse>("/api/v1/artists");
+    if (!res.ok) return [];
+    return res.data?.data ?? [];
+  },
+
+  uploadSong: async (
+    file: File,
+    meta: {
+      title: string;
+      isKaraoke: boolean;
+      musicArtistId?: string;
+    },
+  ): Promise<MusicTrack> => {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3002";
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("access_token")
+        : null;
+
+    const formData = new FormData();
+    formData.append("fileData", file);
+    formData.append("title", meta.title);
+    formData.append("isKaraoke", String(meta.isKaraoke));
+    formData.append("release_date", new Date().toISOString());
+    formData.append("fileType", meta.isKaraoke ? "KARAOKE" : "MUSIC");
+
+    if (meta.musicArtistId) {
+      formData.append("musicArtistId", meta.musicArtistId);
+    }
+
+    const response = await fetch(`${baseUrl}/api/v1/music/create`, {
+      method: "POST",
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: formData,
+    });
+
+    const json = await response.json();
+    if (!response.ok)
+      throw new Error(json?.message || "Failed to upload song");
+    return json?.data ?? json;
+  },
+
+  deleteSong: async (id: string): Promise<void> => {
+    const res = await api.delete(`/api/v1/music/delete/${id}`);
+    if (!res.ok)
+      throw new Error(
+        (res.data as any)?.message || "Failed to delete song",
+      );
+  },
+};

--- a/modules/collaboration/components/KaraokePage.tsx
+++ b/modules/collaboration/components/KaraokePage.tsx
@@ -1,73 +1,149 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Edit, Trash2, Eye, X } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useState } from "react";
-
-import {
-  mockKaraokeSongs,
-  mockKaraokeRecordings,
-} from "@/modules/collaboration/constants/mock-data";
+import { motion, AnimatePresence } from "framer-motion";
+import { Plus, Edit, Trash2, Eye, X, RefreshCw } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useKaraokeSongs, useUploadSong, useDeleteSong } from "@/modules/collaboration/hooks/useMusic";
 import type { KaraokeTabId } from "@/modules/collaboration/types";
 
-export const KaraokePage = () => {
+interface KaraokePageProps {
+  isDark?: boolean;
+}
+
+export const KaraokePage = ({ isDark: isDarkProp }: KaraokePageProps) => {
   const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
-  const [showAddModal, setShowAddModal] = useState<boolean>(false);
+  const isDark = isDarkProp ?? resolvedTheme === "dark";
+
+  const [showAddModal, setShowAddModal] = useState(false);
   const [activeTab, setActiveTab] = useState<KaraokeTabId>("songs");
 
-  const labelClass = `block text-sm font-medium mb-2 ${isDark ? "text-gray-300" : "text-gray-700"}`;
+  const [songTitle, setSongTitle]     = useState("");
+  const [artist, setArtist]           = useState("");
+  const [audioFile, setAudioFile]     = useState<File | null>(null);
+  const [lyricsFile, setLyricsFile]   = useState<File | null>(null);
+  const [videoFile, setVideoFile]     = useState<File | null>(null);
+  const [artistError, setArtistError] = useState(false);
+  const [mp3Error, setMp3Error] = useState(false);
+  const [jsonError, setJsonError] = useState(false);
+
+  const { data, isLoading, isError, refetch } = useKaraokeSongs();
+  const uploadSong  = useUploadSong(true);
+  const deleteSong  = useDeleteSong(true);
+
+  const songs = data?.data ?? [];
+
+  const labelClass = `block text-sm font-medium mb-2 ${
+    isDark ? "text-gray-300" : "text-gray-700"
+  }`;
+
+  const resetForm = () => {
+    setSongTitle(""); setArtist("");
+    setAudioFile(null); setLyricsFile(null); setVideoFile(null);
+    setArtistError(false);
+    setMp3Error(false);
+    setJsonError(false);
+  };
+
+  const handleSave = async () => {
+    if (!songTitle.trim() || !audioFile || !lyricsFile) return;
+    if (!artist.trim()) {
+      setArtistError(true);
+      return;
+    }
+    setArtistError(false);
+    try {
+      await uploadSong.mutateAsync({
+        file: audioFile,
+        meta: { title: songTitle.trim() },
+      });
+      resetForm();
+      setShowAddModal(false);
+    } catch (err: any) {
+      console.error("[KaraokePage] Upload error:", err);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteSong.mutateAsync(id);
+    } catch (err: any) {
+      console.error("[KaraokePage] Delete error:", err);
+    }
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "—";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
 
   return (
     <div>
+      {/* Header */}
       <motion.div
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.5 }}
         className="mb-8"
       >
-        <h1
-          className={`text-3xl font-bold mb-2 ${isDark ? "text-white" : "text-gray-900"}`}
-        >
-          Karaoke Management
-        </h1>
-        <p className={isDark ? "text-gray-400" : "text-gray-600"}>
-          Manage karaoke songs, lyrics, and fan recordings
-        </p>
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className={`text-3xl font-bold mb-2 ${isDark ? "text-white" : "text-gray-900"}`}>
+              Karaoke Management
+            </h1>
+            <p className={isDark ? "text-gray-400" : "text-gray-600"}>
+              Manage karaoke songs, lyrics, and fan recordings
+            </p>
+          </div>
+          <button
+            onClick={() => refetch()}
+            className={`p-2.5 rounded-xl border transition-colors ${
+              isDark
+                ? "border-gray-700 hover:bg-gray-800 text-gray-400"
+                : "border-gray-200 hover:bg-gray-100 text-gray-600"
+            }`}
+            title="Refresh"
+          >
+            <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
       </motion.div>
 
+      {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         {[
-          { label: "Total Karaoke Songs", value: "1,200" },
-          { label: "Most Sung Song", value: "Dynamite" },
-          { label: "Active Tracks", value: "980" },
-          { label: "Total Recordings", value: "5,400" },
-        ].map((stat, index) => (
+          { label: "Total Karaoke Songs", value: data?.meta?.total ?? songs.length },
+          { label: "Active Tracks",       value: songs.filter(s => !s.status).length || songs.length },
+          { label: "Most Sung Song",      value: songs[0]?.title ?? "—" },
+          { label: "Total Recordings",    value: "—" },
+        ].map((stat, i) => (
           <motion.div
             key={stat.label}
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.1 * index }}
-            className={`p-6 rounded-lg border ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"}`}
+            transition={{ duration: 0.5, delay: 0.1 * i }}
+            className={`p-6 rounded-xl border ${
+              isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+            }`}
           >
-            <p
-              className={`text-sm mb-1 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-            >
+            <p className={`text-sm mb-1 ${isDark ? "text-gray-400" : "text-gray-600"}`}>
               {stat.label}
             </p>
-            <p
-              className={`text-2xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}
-            >
-              {stat.value}
+            <p className={`text-2xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}>
+              {isLoading ? (
+                <span className={`inline-block h-7 w-16 rounded animate-pulse ${isDark ? "bg-gray-700" : "bg-gray-200"}`} />
+              ) : (
+                stat.value
+              )}
             </p>
           </motion.div>
         ))}
       </div>
 
-      <div
-        className={`border-b mb-6 ${isDark ? "border-gray-700" : "border-gray-200"}`}
-      >
+      {/* Tabs */}
+      <div className={`border-b mb-6 ${isDark ? "border-gray-700" : "border-gray-200"}`}>
         <div className="flex gap-6">
           {(["songs", "recordings"] as const).map((tab) => (
             <button
@@ -77,8 +153,8 @@ export const KaraokePage = () => {
                 activeTab === tab
                   ? "border-[#A53860] text-[#A53860]"
                   : isDark
-                    ? "border-transparent text-gray-400 hover:text-gray-300"
-                    : "border-transparent text-gray-600 hover:text-gray-900"
+                  ? "border-transparent text-gray-400 hover:text-gray-300"
+                  : "border-transparent text-gray-600 hover:text-gray-900"
               }`}
             >
               {tab}
@@ -87,222 +163,393 @@ export const KaraokePage = () => {
         </div>
       </div>
 
+      {/* Songs Tab */}
       {activeTab === "songs" && (
         <>
           <div className="mb-6">
             <button
               onClick={() => setShowAddModal(true)}
-              className="px-6 py-3 rounded-lg bg-linear-to-r from-[#A53860] to-[#670D2F] text-white font-medium hover:opacity-90 flex items-center gap-2"
+              className="px-6 py-3 rounded-xl bg-gradient-to-r from-[#A53860] to-[#670D2F] text-white font-medium hover:opacity-90 flex items-center gap-2 transition-all"
             >
               <Plus className="w-4 h-4" /> Add Karaoke Song
             </button>
           </div>
-          <div
-            className={`rounded-lg border overflow-hidden ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"}`}
-          >
-            <table className="w-full">
-              <thead className={isDark ? "bg-gray-900" : "bg-gray-50"}>
-                <tr>
-                  {[
-                    "Title",
-                    "Artist",
-                    "Lyrics",
-                    "Duration",
-                    "Status",
-                    "Actions",
-                  ].map((h) => (
-                    <th
-                      key={h}
-                      className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${isDark ? "text-gray-400" : "text-gray-500"}`}
-                    >
-                      {h}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody
-                className={`divide-y ${isDark ? "divide-gray-700" : "divide-gray-200"}`}
-              >
-                {mockKaraokeSongs.map((song) => (
-                  <tr
-                    key={song.id}
-                    className={
-                      isDark ? "hover:bg-gray-700" : "hover:bg-gray-50"
-                    }
-                  >
-                    <td
-                      className={`px-6 py-4 font-medium ${isDark ? "text-white" : "text-gray-900"}`}
-                    >
-                      {song.title}
-                    </td>
-                    <td
-                      className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                    >
-                      {song.artist}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span className="px-2 py-1 text-xs rounded-full bg-green-100 text-green-800">
-                        {song.lyrics}
-                      </span>
-                    </td>
-                    <td
-                      className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                    >
-                      {song.duration}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`px-2 py-1 text-xs rounded-full ${song.status === "Active" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"}`}
+
+          {isError && (
+            <div className={`mb-4 p-4 rounded-xl border ${
+              isDark ? "bg-red-900/20 border-red-800/40 text-red-400" : "bg-red-50 border-red-200 text-red-700"
+            }`}>
+              Failed to load karaoke songs.{" "}
+              <button onClick={() => refetch()} className="underline">
+                Try again
+              </button>
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className={`rounded-xl border p-16 text-center ${
+              isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+            }`}>
+              <div className="w-10 h-10 border-4 border-[#A53860]/20 border-t-[#A53860] rounded-full animate-spin mx-auto mb-4" />
+              <p className={`text-sm ${isDark ? "text-gray-400" : "text-gray-500"}`}>
+                Loading karaoke songs...
+              </p>
+            </div>
+          ) : songs.length === 0 ? (
+            <div className={`rounded-xl border p-16 text-center ${
+              isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+            }`}>
+              <div className="text-5xl mb-4">🎤</div>
+              <p className={`text-lg font-semibold mb-1 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                No karaoke songs yet
+              </p>
+              <p className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+                Click &quot;Add Karaoke Song&quot; to add your first song
+              </p>
+            </div>
+          ) : (
+            <div className={`rounded-xl border overflow-hidden ${
+              isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+            }`}>
+              <table className="w-full">
+                <thead className={isDark ? "bg-gray-900" : "bg-gray-50"}>
+                  <tr>
+                    {["Title", "Artist", "Duration", "Type", "Actions"].map((h) => (
+                      <th
+                        key={h}
+                        className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
+                          isDark ? "text-gray-400" : "text-gray-500"
+                        }`}
                       >
-                        {song.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex gap-2">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className={`divide-y ${isDark ? "divide-gray-700" : "divide-gray-200"}`}>
+                  {songs.map((song) => (
+                    <tr
+                      key={song.id}
+                      className={isDark ? "hover:bg-gray-700" : "hover:bg-gray-50"}
+                    >
+                      <td className={`px-6 py-4 font-medium ${isDark ? "text-white" : "text-gray-900"}`}>
+                        {song.title}
+                      </td>
+                      <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                        {song.musicArtist?.name ?? "—"}
+                      </td>
+                      <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                        {formatDuration(song.duration)}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className="px-2 py-1 text-xs rounded-full bg-[#A53860]/10 text-[#A53860]">
+                          Karaoke
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
                         <button
-                          className={`p-2 rounded-lg ${isDark ? "hover:bg-gray-600" : "hover:bg-gray-100"}`}
-                        >
-                          <Edit
-                            className={`w-4 h-4 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-                          />
-                        </button>
-                        <button
-                          className={`p-2 rounded-lg ${isDark ? "hover:bg-red-500/20" : "hover:bg-red-50"}`}
+                          onClick={() => handleDelete(song.id)}
+                          disabled={deleteSong.isPending}
+                          className={`p-2 rounded-lg transition-colors ${
+                            isDark ? "hover:bg-red-500/20" : "hover:bg-red-50"
+                          } disabled:opacity-50`}
                         >
                           <Trash2 className="w-4 h-4 text-red-500" />
                         </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </>
       )}
 
+      {/* Recordings Tab */}
       {activeTab === "recordings" && (
-        <div
-          className={`rounded-lg border overflow-hidden ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"}`}
-        >
-          <table className="w-full">
-            <thead className={isDark ? "bg-gray-900" : "bg-gray-50"}>
-              <tr>
-                {["User", "Song", "Room", "Date", "Views", "Actions"].map(
-                  (h) => (
-                    <th
-                      key={h}
-                      className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${isDark ? "text-gray-400" : "text-gray-500"}`}
-                    >
-                      {h}
-                    </th>
-                  ),
-                )}
-              </tr>
-            </thead>
-            <tbody
-              className={`divide-y ${isDark ? "divide-gray-700" : "divide-gray-200"}`}
-            >
-              {mockKaraokeRecordings.map((rec) => (
-                <tr
-                  key={rec.id}
-                  className={isDark ? "hover:bg-gray-700" : "hover:bg-gray-50"}
-                >
-                  <td
-                    className={`px-6 py-4 font-medium ${isDark ? "text-white" : "text-gray-900"}`}
-                  >
-                    {rec.user}
-                  </td>
-                  <td
-                    className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                  >
-                    {rec.song}
-                  </td>
-                  <td
-                    className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                  >
-                    {rec.room}
-                  </td>
-                  <td
-                    className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                  >
-                    {rec.date}
-                  </td>
-                  <td
-                    className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                  >
-                    {rec.views.toLocaleString()}
-                  </td>
-                  <td className="px-6 py-4">
-                    <button
-                      className={`p-2 rounded-lg ${isDark ? "hover:bg-gray-600" : "hover:bg-gray-100"}`}
-                    >
-                      <Eye
-                        className={`w-4 h-4 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-                      />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className={`rounded-xl border p-16 text-center ${
+          isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+        }`}>
+          <div className="text-5xl mb-4">🎵</div>
+          <p className={`text-lg font-semibold mb-1 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+            No recordings yet
+          </p>
+          <p className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+            Fan recordings will appear here
+          </p>
         </div>
       )}
 
+      {/* Add Modal */}
       <AnimatePresence>
         {showAddModal && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
-            onClick={() => setShowAddModal(false)}
+            className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+            onClick={() => { setShowAddModal(false); resetForm(); }}
           >
             <motion.div
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.9, opacity: 0 }}
+              initial={{ scale: 0.95, opacity: 0, y: 10 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.95, opacity: 0, y: 10 }}
+              transition={{ duration: 0.2 }}
               onClick={(e) => e.stopPropagation()}
-              className={`w-full max-w-md rounded-2xl p-6 shadow-2xl ${isDark ? "bg-gray-900 border border-gray-700" : "bg-white border border-gray-200"}`}
+              className={`w-full max-w-2xl rounded-2xl p-8 shadow-2xl ${
+                isDark
+                  ? "bg-[#1a2035] border border-gray-700/50"
+                  : "bg-white border border-gray-200"
+              }`}
             >
-              <div className="flex items-center justify-between mb-6">
-                <h3
-                  className={`text-xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}
-                >
-                  Add Karaoke Song
-                </h3>
-                <button
-                  onClick={() => setShowAddModal(false)}
-                  className={`p-2 rounded-lg ${isDark ? "hover:bg-gray-800" : "hover:bg-gray-100"}`}
-                >
-                  <X
-                    className={`w-5 h-5 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-                  />
-                </button>
-              </div>
-              <div className="space-y-4">
-                {["Title", "Artist"].map((field) => (
-                  <div key={field}>
-                    <label className={labelClass}>{field}</label>
+              <h3 className={`text-xl font-bold mb-6 ${isDark ? "text-white" : "text-gray-900"}`}>
+                Add Karaoke Song
+              </h3>
+
+              <div className="space-y-5">
+                {/* Title + Artist */}
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className={labelClass}>
+                      Song Title <span className="text-red-500">*</span>
+                    </label>
                     <input
                       type="text"
-                      placeholder={`Enter ${field.toLowerCase()}`}
-                      className={`w-full h-11 px-4 rounded-xl border text-sm ${isDark ? "bg-gray-800 border-gray-700 text-white placeholder-gray-400" : "bg-gray-50 border-gray-200 text-gray-900"} focus:outline-none focus:ring-2 focus:ring-[#A53860]/50`}
+                      placeholder="e.g., Butter"
+                      value={songTitle}
+                      onChange={(e) => setSongTitle(e.target.value)}
+                      className={`w-full h-11 px-4 rounded-xl border text-sm outline-none transition-all ${
+                        isDark
+                          ? "bg-[#243050] border-gray-600/50 text-white placeholder-gray-500 focus:border-[#A53860]"
+                          : "bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-400 focus:border-[#A53860]"
+                      } focus:ring-2 focus:ring-[#A53860]/10`}
                     />
                   </div>
-                ))}
-                <div className="flex gap-3 pt-2">
+                  <div>
+                    <label className={labelClass}>
+                      Artist <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="e.g., BTS"
+                      value={artist}
+                      onChange={(e) => {
+                        setArtist(e.target.value);
+                        if (e.target.value.trim()) setArtistError(false);
+                      }}
+                      className={`w-full h-11 px-4 rounded-xl border text-sm outline-none transition-all ${
+                        isDark
+                          ? "bg-[#243050] border-gray-600/50 text-white placeholder-gray-500 focus:border-[#A53860]"
+                          : "bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-400 focus:border-[#A53860]"
+                      } focus:ring-2 focus:ring-[#A53860]/10`}
+                    />
+                    {artistError && (
+                      <p className="text-red-500 text-xs mt-1">
+                        Artist is required
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Audio File */}
+                <div>
+                  <label className={labelClass}>
+                    Upload Karaoke Audio <span className="text-red-500">*</span>
+                  </label>
+                  <div className="relative">
+                    <label className={`flex items-center w-full h-11 px-4 rounded-xl border text-sm cursor-pointer transition-all ${
+                      isDark
+                        ? "bg-[#243050] border-gray-600/50 text-gray-400 hover:border-[#A53860]/50"
+                        : "bg-gray-50 border-gray-200 text-gray-500 hover:border-[#A53860]/50"
+                    }`}>
+                      <input
+                        type="file"
+                        accept=".mp3,audio/mpeg"
+                        className="sr-only"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0] ?? null;
+                          if (file && !file.name.toLowerCase().endsWith(".mp3")) {
+                            e.target.value = "";
+                            setAudioFile(null);
+                            setMp3Error(true);
+                            setTimeout(() => setMp3Error(false), 4000);
+                            return;
+                          }
+                          setMp3Error(false);
+                          setAudioFile(file);
+                        }}
+                      />
+                      {audioFile ? (
+                        <span className={`text-sm ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                          {audioFile.name}
+                        </span>
+                      ) : (
+                        <>
+                          <span className={`text-sm ${isDark ? "text-gray-400" : "text-gray-500"}`}>Choose file</span>
+                          <span className={`ml-2 text-sm ${isDark ? "text-gray-600" : "text-gray-400"}`}>No file chosen</span>
+                        </>
+                      )}
+                    </label>
+                    {audioFile && (
+                      <button
+                        type="button"
+                        onClick={() => setAudioFile(null)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-red-500/20 transition-colors"
+                      >
+                        <X className={`w-4 h-4 ${isDark ? "text-gray-400 hover:text-red-400" : "text-gray-500 hover:text-red-500"}`} />
+                      </button>
+                    )}
+                  </div>
+                  <p className={`text-xs mt-1.5 ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+                    Only .mp3 files are accepted
+                  </p>
+                  {mp3Error && (
+                    <motion.p
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0 }}
+                      className="text-xs mt-1 text-red-500 font-medium flex items-center gap-1"
+                    >
+                      ✕ Invalid file type. Please upload an MP3 file only.
+                    </motion.p>
+                  )}
+                </div>
+
+                {/* Lyrics File */}
+                <div>
+                  <label className={labelClass}>
+                    Upload Lyrics File (JSON) <span className="text-red-500">*</span>
+                  </label>
+                  <div className="relative">
+                    <label className={`flex items-center w-full h-11 px-4 rounded-xl border text-sm cursor-pointer transition-all ${
+                      isDark
+                        ? "bg-[#243050] border-gray-600/50 text-gray-400 hover:border-[#A53860]/50"
+                        : "bg-gray-50 border-gray-200 text-gray-500 hover:border-[#A53860]/50"
+                    }`}>
+                      <input
+                        type="file"
+                        accept=".json,application/json"
+                        className="sr-only"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0] ?? null;
+                          if (file && !file.name.toLowerCase().endsWith(".json")) {
+                            e.target.value = "";
+                            setLyricsFile(null);
+                            setJsonError(true);
+                            setTimeout(() => setJsonError(false), 4000);
+                            return;
+                          }
+                          setJsonError(false);
+                          setLyricsFile(file);
+                        }}
+                      />
+                      {lyricsFile ? (
+                        <span className={`text-sm ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                          {lyricsFile.name}
+                        </span>
+                      ) : (
+                        <>
+                          <span className={`text-sm ${isDark ? "text-gray-400" : "text-gray-500"}`}>Choose file</span>
+                          <span className={`ml-2 text-sm ${isDark ? "text-gray-600" : "text-gray-400"}`}>No .json file chosen</span>
+                        </>
+                      )}
+                    </label>
+                    {lyricsFile && (
+                      <button
+                        type="button"
+                        onClick={() => setLyricsFile(null)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-red-500/20 transition-colors"
+                      >
+                        <X className={`w-4 h-4 ${isDark ? "text-gray-400 hover:text-red-400" : "text-gray-500 hover:text-red-500"}`} />
+                      </button>
+                    )}
+                  </div>
+                  <p className={`text-xs mt-1.5 ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+                    Only .json files are accepted
+                  </p>
+                  {jsonError && (
+                    <motion.p
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0 }}
+                      className="text-xs mt-1 text-red-500 font-medium flex items-center gap-1"
+                    >
+                      ✕ Invalid file type. Please upload a JSON file only.
+                    </motion.p>
+                  )}
+                </div>
+
+                {/* Video File */}
+                <div>
+                  <label className={labelClass}>Upload Background Video (Optional)</label>
+                  <div className="relative">
+                    <label className={`flex items-center w-full h-11 px-4 rounded-xl border text-sm cursor-pointer transition-all ${
+                      isDark
+                        ? "bg-[#243050] border-gray-600/50 text-gray-400 hover:border-[#A53860]/50"
+                        : "bg-gray-50 border-gray-200 text-gray-500 hover:border-[#A53860]/50"
+                    }`}>
+                      <input
+                        type="file"
+                        accept="video/*"
+                        className="sr-only"
+                        onChange={(e) => setVideoFile(e.target.files?.[0] ?? null)}
+                      />
+                      {videoFile ? (
+                        <span className={`text-sm ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                          {videoFile.name}
+                        </span>
+                      ) : (
+                        <>
+                          <span className={`text-sm ${isDark ? "text-gray-400" : "text-gray-500"}`}>Choose file</span>
+                          <span className={`ml-2 text-sm ${isDark ? "text-gray-600" : "text-gray-400"}`}>No file chosen</span>
+                        </>
+                      )}
+                    </label>
+                    {videoFile && (
+                      <button
+                        type="button"
+                        onClick={() => setVideoFile(null)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-red-500/20 transition-colors"
+                      >
+                        <X className={`w-4 h-4 ${isDark ? "text-gray-400 hover:text-red-400" : "text-gray-500 hover:text-red-500"}`} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Error */}
+                {uploadSong.isError && (
+                  <p className="text-red-500 text-sm">
+                    {(uploadSong.error as any)?.message || "Upload failed. Please try again."}
+                  </p>
+                )}
+
+                {/* Buttons */}
+                <div className="flex items-center justify-end gap-3 pt-2">
                   <button
-                    onClick={() => setShowAddModal(false)}
-                    className={`flex-1 h-11 rounded-xl font-semibold ${isDark ? "bg-gray-800 text-gray-300 hover:bg-gray-700" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+                    onClick={() => { setShowAddModal(false); resetForm(); }}
+                    disabled={uploadSong.isPending}
+                    className={`px-6 h-11 rounded-xl font-semibold text-sm transition-colors disabled:opacity-50 ${
+                      isDark
+                        ? "bg-[#243050] text-gray-300 hover:bg-gray-700"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    }`}
                   >
                     Cancel
                   </button>
                   <button
-                    onClick={() => setShowAddModal(false)}
-                    className="flex-1 h-11 rounded-xl font-semibold bg-linear-to-r from-[#A53860] to-[#670D2F] text-white hover:opacity-90"
+                    onClick={handleSave}
+                    disabled={
+                      !songTitle.trim() ||
+                      !artist.trim() ||
+                      !audioFile ||
+                      !lyricsFile ||
+                      uploadSong.isPending
+                    }
+                    className="px-6 h-11 rounded-xl font-semibold text-sm bg-gradient-to-r from-[#A53860] to-[#670D2F] text-white hover:opacity-90 transition-all disabled:opacity-50 disabled:pointer-events-none"
                   >
-                    Add Song
+                    {uploadSong.isPending ? "Saving..." : "Save Karaoke Song"}
                   </button>
                 </div>
               </div>

--- a/modules/collaboration/components/MusicPage.tsx
+++ b/modules/collaboration/components/MusicPage.tsx
@@ -1,241 +1,362 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Edit, Trash2, Volume2, VolumeX, X } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Plus, Trash2, X, RefreshCw } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useSongs, useUploadSong, useDeleteSong, useArtists } from "@/modules/collaboration/hooks/useMusic";
 
-import { mockMusicSongs } from "@/modules/collaboration/constants/mock-data";
+interface MusicPageProps {
+  isDark?: boolean;
+}
 
-export const MusicPage = () => {
+export const MusicPage = ({ isDark: isDarkProp }: MusicPageProps) => {
   const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
-  const [showAddModal, setShowAddModal] = useState<boolean>(false);
+  const isDark = isDarkProp ?? resolvedTheme === "dark";
 
-  const selectClass = `w-full px-3 py-2 rounded-lg border text-sm ${
-    isDark
-      ? "bg-gray-700 border-gray-600 text-white"
-      : "bg-white border-gray-300 text-gray-900"
-  } focus:outline-none focus:ring-2 focus:ring-[#A53860]/50`;
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [songTitle, setSongTitle] = useState("");
+  const [artist, setArtist] = useState("");
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [artistError, setArtistError] = useState(false);
 
-  const labelClass = `block text-sm font-medium mb-2 ${isDark ? "text-gray-300" : "text-gray-700"}`;
+  const { data, isLoading, isError, refetch } = useSongs();
+  const { data: artists = [] } = useArtists();
+  const uploadSong = useUploadSong(false);
+  const deleteSong = useDeleteSong(false);
+
+  const [selectedArtistId, setSelectedArtistId] = useState<string>("");
+
+  const songs = data?.data ?? [];
+
+  const labelClass = `block text-sm font-medium mb-2 ${isDark ? "text-gray-300" : "text-gray-700"
+    }`;
+
+  const resetForm = () => {
+    setSongTitle("");
+    setArtist("");
+    setSelectedArtistId("");
+    setAudioFile(null);
+    setArtistError(false);
+  };
+
+  const handleSave = async () => {
+    if (!songTitle.trim() || !audioFile) return;
+    if (!selectedArtistId) {
+      setArtistError(true);
+      return;
+    }
+    setArtistError(false);
+    try {
+      await uploadSong.mutateAsync({
+        file: audioFile,
+        meta: {
+          title: songTitle.trim(),
+          musicArtistId: selectedArtistId,
+        },
+      });
+      resetForm();
+      setShowAddModal(false);
+    } catch (err: any) {
+      console.error("[MusicPage] Upload error:", err);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteSong.mutateAsync(id);
+    } catch (err: any) {
+      console.error("[MusicPage] Delete error:", err);
+    }
+  };
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return "—";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
 
   return (
     <div>
+      {/* Header */}
       <motion.div
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.5 }}
         className="mb-8"
       >
-        <h1
-          className={`text-3xl font-bold mb-2 ${isDark ? "text-white" : "text-gray-900"}`}
-        >
-          Music Management
-        </h1>
-        <p className={isDark ? "text-gray-400" : "text-gray-600"}>
-          Manage music library for collaboration rooms
-        </p>
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className={`text-3xl font-bold mb-2 ${isDark ? "text-white" : "text-gray-900"}`}>
+              Song Management
+            </h1>
+            <p className={isDark ? "text-gray-400" : "text-gray-600"}>
+              Manage and upload songs to the platform
+            </p>
+          </div>
+          <button
+            onClick={() => refetch()}
+            className={`p-2.5 rounded-xl border transition-colors ${isDark
+                ? "border-gray-700 hover:bg-gray-800 text-gray-400"
+                : "border-gray-200 hover:bg-gray-100 text-gray-600"
+              }`}
+            title="Refresh"
+          >
+            <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
       </motion.div>
 
+      {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         {[
-          { label: "Total Songs", value: "2,300" },
-          { label: "Total Artists", value: "450" },
-          { label: "Most Used", value: "Dynamite" },
-          { label: "Active Songs", value: "1,800" },
-        ].map((stat, index) => (
+          { label: "Total Songs", value: data?.meta?.total ?? songs.length },
+          { label: "Active Tracks", value: songs.length },
+          { label: "Top Artist", value: songs[0]?.musicArtist?.name ?? "—" },
+          { label: "Last Uploaded", value: songs[0] ? new Date(songs[0].createdAt).toLocaleDateString() : "—" },
+        ].map((stat, i) => (
           <motion.div
             key={stat.label}
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.1 * index }}
-            className={`p-6 rounded-lg border ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"}`}
+            transition={{ duration: 0.5, delay: 0.1 * i }}
+            className={`p-6 rounded-xl border ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+              }`}
           >
-            <p
-              className={`text-sm mb-1 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-            >
+            <p className={`text-sm mb-1 ${isDark ? "text-gray-400" : "text-gray-600"}`}>
               {stat.label}
             </p>
-            <p
-              className={`text-2xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}
-            >
-              {stat.value}
+            <p className={`text-2xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}>
+              {isLoading ? (
+                <span className={`inline-block h-7 w-16 rounded animate-pulse ${isDark ? "bg-gray-700" : "bg-gray-200"}`} />
+              ) : (
+                stat.value
+              )}
             </p>
           </motion.div>
         ))}
       </div>
 
+      {/* Add Button */}
       <div className="mb-6">
         <button
           onClick={() => setShowAddModal(true)}
-          className="px-6 py-3 rounded-lg bg-linear-to-r from-[#A53860] to-[#670D2F] text-white font-medium hover:opacity-90 flex items-center gap-2"
+          className="px-6 py-3 rounded-xl bg-gradient-to-r from-[#A53860] to-[#670D2F] text-white font-medium hover:opacity-90 flex items-center gap-2 transition-all"
         >
-          <Plus className="w-4 h-4" /> Add Music
+          <Plus className="w-4 h-4" /> Add Song
         </button>
       </div>
 
-      <div
-        className={`rounded-lg border overflow-hidden ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"}`}
-      >
-        <table className="w-full">
-          <thead className={isDark ? "bg-gray-900" : "bg-gray-50"}>
-            <tr>
-              {[
-                "Title",
-                "Artist",
-                "Album",
-                "Genre",
-                "Duration",
-                "Status",
-                "Actions",
-              ].map((h) => (
-                <th
-                  key={h}
-                  className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${isDark ? "text-gray-400" : "text-gray-500"}`}
-                >
-                  {h}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody
-            className={`divide-y ${isDark ? "divide-gray-700" : "divide-gray-200"}`}
-          >
-            {mockMusicSongs.map((song) => (
-              <tr
-                key={song.id}
-                className={isDark ? "hover:bg-gray-700" : "hover:bg-gray-50"}
-              >
-                <td
-                  className={`px-6 py-4 font-medium ${isDark ? "text-white" : "text-gray-900"}`}
-                >
-                  {song.title}
-                </td>
-                <td
-                  className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                >
-                  {song.artist}
-                </td>
-                <td
-                  className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                >
-                  {song.album}
-                </td>
-                <td
-                  className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                >
-                  {song.genre}
-                </td>
-                <td
-                  className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                >
-                  {song.duration}
-                </td>
-                <td className="px-6 py-4">
-                  <span
-                    className={`px-2 py-1 text-xs rounded-full ${song.status === "Active" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"}`}
+      {/* Error */}
+      {isError && (
+        <div className={`mb-4 p-4 rounded-xl border ${isDark ? "bg-red-900/20 border-red-800/40 text-red-400" : "bg-red-50 border-red-200 text-red-700"
+          }`}>
+          Failed to load songs.{" "}
+          <button onClick={() => refetch()} className="underline">Try again</button>
+        </div>
+      )}
+
+      {/* Table / States */}
+      {isLoading ? (
+        <div className={`rounded-xl border p-16 text-center ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+          }`}>
+          <div className="w-10 h-10 border-4 border-[#A53860]/20 border-t-[#A53860] rounded-full animate-spin mx-auto mb-4" />
+          <p className={`text-sm ${isDark ? "text-gray-400" : "text-gray-500"}`}>
+            Loading songs...
+          </p>
+        </div>
+      ) : songs.length === 0 ? (
+        <div className={`rounded-xl border p-16 text-center ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+          }`}>
+          <div className="text-5xl mb-4">🎵</div>
+          <p className={`text-lg font-semibold mb-1 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+            No songs yet
+          </p>
+          <p className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+            Click &quot;Add Song&quot; to upload your first song
+          </p>
+        </div>
+      ) : (
+        <div className={`rounded-xl border overflow-hidden ${isDark ? "bg-gray-800 border-gray-700" : "bg-white border-gray-200"
+          }`}>
+          <table className="w-full">
+            <thead className={isDark ? "bg-gray-900" : "bg-gray-50"}>
+              <tr>
+                {["Title", "Artist", "Album", "Genre", "Duration", "Actions"].map((h) => (
+                  <th
+                    key={h}
+                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${isDark ? "text-gray-400" : "text-gray-500"
+                      }`}
                   >
-                    {song.status}
-                  </span>
-                </td>
-                <td className="px-6 py-4">
-                  <div className="flex gap-2">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className={`divide-y ${isDark ? "divide-gray-700" : "divide-gray-200"}`}>
+              {songs.map((song) => (
+                <tr
+                  key={song.id}
+                  className={isDark ? "hover:bg-gray-700" : "hover:bg-gray-50"}
+                >
+                  <td className={`px-6 py-4 font-medium ${isDark ? "text-white" : "text-gray-900"}`}>
+                    {song.title}
+                  </td>
+                  <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                    {song.musicArtist?.name ?? "—"}
+                  </td>
+                  <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                    {song.musicAlbum?.album ?? "—"}
+                  </td>
+                  <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                    {song.musicAlbum?.genre ?? "—"}
+                  </td>
+                  <td className={`px-6 py-4 ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                    {formatDuration(song.duration)}
+                  </td>
+                  <td className="px-6 py-4">
                     <button
-                      className={`p-2 rounded-lg ${isDark ? "hover:bg-gray-600" : "hover:bg-gray-100"}`}
-                    >
-                      <Edit
-                        className={`w-4 h-4 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-                      />
-                    </button>
-                    <button
-                      className={`p-2 rounded-lg ${isDark ? "hover:bg-yellow-500/20" : "hover:bg-yellow-50"}`}
-                    >
-                      {song.status === "Active" ? (
-                        <VolumeX className="w-4 h-4 text-yellow-600" />
-                      ) : (
-                        <Volume2 className="w-4 h-4 text-green-600" />
-                      )}
-                    </button>
-                    <button
-                      className={`p-2 rounded-lg ${isDark ? "hover:bg-red-500/20" : "hover:bg-red-50"}`}
+                      onClick={() => handleDelete(song.id)}
+                      disabled={deleteSong.isPending}
+                      className={`p-2 rounded-lg transition-colors disabled:opacity-50 ${isDark ? "hover:bg-red-500/20" : "hover:bg-red-50"
+                        }`}
                     >
                       <Trash2 className="w-4 h-4 text-red-500" />
                     </button>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
+      {/* Add Modal */}
       <AnimatePresence>
         {showAddModal && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
-            onClick={() => setShowAddModal(false)}
+            className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+            onClick={() => { setShowAddModal(false); resetForm(); }}
           >
             <motion.div
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.9, opacity: 0 }}
+              initial={{ scale: 0.95, opacity: 0, y: 10 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.95, opacity: 0, y: 10 }}
+              transition={{ duration: 0.2 }}
               onClick={(e) => e.stopPropagation()}
-              className={`w-full max-w-md rounded-2xl p-6 shadow-2xl ${isDark ? "bg-gray-900 border border-gray-700" : "bg-white border border-gray-200"}`}
+              className={`w-full max-w-lg rounded-2xl p-8 shadow-2xl ${isDark
+                  ? "bg-[#1a2035] border border-gray-700/50"
+                  : "bg-white border border-gray-200"
+                }`}
             >
               <div className="flex items-center justify-between mb-6">
-                <h3
-                  className={`text-xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}
-                >
+                <h3 className={`text-xl font-bold ${isDark ? "text-white" : "text-gray-900"}`}>
                   Add Song
                 </h3>
                 <button
-                  onClick={() => setShowAddModal(false)}
+                  onClick={() => { setShowAddModal(false); resetForm(); }}
                   className={`p-2 rounded-lg ${isDark ? "hover:bg-gray-800" : "hover:bg-gray-100"}`}
                 >
-                  <X
-                    className={`w-5 h-5 ${isDark ? "text-gray-400" : "text-gray-600"}`}
-                  />
+                  <X className={`w-5 h-5 ${isDark ? "text-gray-400" : "text-gray-600"}`} />
                 </button>
               </div>
+
               <div className="space-y-4">
-                {["Title", "Artist", "Album"].map((field) => (
-                  <div key={field}>
-                    <label className={labelClass}>{field}</label>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className={labelClass}>
+                      Song Title <span className="text-red-500">*</span>
+                    </label>
                     <input
                       type="text"
-                      placeholder={`Enter ${field.toLowerCase()}`}
-                      className={`w-full h-11 px-4 rounded-xl border text-sm ${isDark ? "bg-gray-800 border-gray-700 text-white placeholder-gray-400" : "bg-gray-50 border-gray-200 text-gray-900"} focus:outline-none focus:ring-2 focus:ring-[#A53860]/50`}
+                      placeholder="e.g., Dynamite"
+                      value={songTitle}
+                      onChange={(e) => setSongTitle(e.target.value)}
+                      className={`w-full h-11 px-4 rounded-xl border text-sm outline-none transition-all ${isDark
+                          ? "bg-[#243050] border-gray-600/50 text-white placeholder-gray-500 focus:border-[#A53860]"
+                          : "bg-gray-50 border-gray-200 text-gray-900 focus:border-[#A53860]"
+                        } focus:ring-2 focus:ring-[#A53860]/10`}
                     />
                   </div>
-                ))}
-                <div>
-                  <label className={labelClass}>Genre</label>
-                  <select className={selectClass}>
-                    <option value="">Select Genre</option>
-                    <option>Pop</option>
-                    <option>K-Pop</option>
-                    <option>Hip-Hop</option>
-                    <option>R&B</option>
-                    <option>Rock</option>
-                    <option>Jazz</option>
-                  </select>
+                  <div>
+                    <label className={labelClass}>
+                      Artist <span className="text-red-500">*</span>
+                    </label>
+                    <select
+                      value={selectedArtistId}
+                      onChange={(e) => {
+                        setSelectedArtistId(e.target.value);
+                        if (e.target.value) setArtistError(false);
+                      }}
+                      className={`w-full h-11 px-4 rounded-xl border text-sm outline-none transition-all ${
+                        isDark
+                          ? "bg-[#243050] border-gray-600/50 text-white focus:border-[#A53860]"
+                          : "bg-gray-50 border-gray-200 text-gray-900 focus:border-[#A53860]"
+                      } focus:ring-2 focus:ring-[#A53860]/10`}
+                    >
+                      <option value="">Select artist...</option>
+                      {artists.map((a) => (
+                        <option key={a.id} value={a.id}>
+                          {a.name}
+                        </option>
+                      ))}
+                    </select>
+                    {artistError && (
+                      <p className="text-red-500 text-xs mt-1">
+                        Artist is required
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <div className="flex gap-3 pt-2">
+
+                <div>
+                  <label className={labelClass}>
+                    Upload Audio File <span className="text-red-500">*</span>
+                  </label>
+                  <label className={`flex items-center w-full h-11 px-4 rounded-xl border text-sm cursor-pointer transition-all ${isDark
+                      ? "bg-[#243050] border-gray-600/50 text-gray-400 hover:border-[#A53860]/50"
+                      : "bg-gray-50 border-gray-200 text-gray-500 hover:border-[#A53860]/50"
+                    }`}>
+                    <input
+                      type="file"
+                      accept="audio/*"
+                      className="sr-only"
+                      onChange={(e) => setAudioFile(e.target.files?.[0] ?? null)}
+                    />
+                    <span className="text-sm">Choose file</span>
+                    <span className={`ml-2 text-sm ${isDark ? "text-gray-600" : "text-gray-400"}`}>
+                      {audioFile ? audioFile.name : "No file chosen"}
+                    </span>
+                  </label>
+                </div>
+
+                {uploadSong.isError && (
+                  <p className="text-red-500 text-sm">
+                    {(uploadSong.error as any)?.message || "Upload failed."}
+                  </p>
+                )}
+
+                <div className="flex items-center justify-end gap-3 pt-2">
                   <button
-                    onClick={() => setShowAddModal(false)}
-                    className={`flex-1 h-11 rounded-xl font-semibold ${isDark ? "bg-gray-800 text-gray-300 hover:bg-gray-700" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+                    onClick={() => { setShowAddModal(false); resetForm(); }}
+                    disabled={uploadSong.isPending}
+                    className={`px-6 h-11 rounded-xl font-semibold text-sm disabled:opacity-50 ${isDark
+                        ? "bg-[#243050] text-gray-300 hover:bg-gray-700"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                      }`}
                   >
                     Cancel
                   </button>
                   <button
-                    onClick={() => setShowAddModal(false)}
-                    className="flex-1 h-11 rounded-xl font-semibold bg-linear-to-r from-[#A53860] to-[#670D2F] text-white hover:opacity-90"
+                    onClick={handleSave}
+                    disabled={!songTitle.trim() || !selectedArtistId || !audioFile || uploadSong.isPending}
+                    className="px-6 h-11 rounded-xl font-semibold text-sm bg-gradient-to-r from-[#A53860] to-[#670D2F] text-white hover:opacity-90 transition-all disabled:opacity-50 disabled:pointer-events-none"
                   >
-                    Add Song
+                    {uploadSong.isPending ? "Saving..." : "Save Song"}
                   </button>
                 </div>
               </div>

--- a/modules/collaboration/hooks/useMusic.ts
+++ b/modules/collaboration/hooks/useMusic.ts
@@ -1,0 +1,61 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { musicService, type ArtistOption } from "@/modules/collaboration/api/music.service";
+
+const SONGS_KEY  = ["music-songs"];
+const KARAOKE_KEY = ["music-karaoke"];
+
+export const useSongs = () =>
+  useQuery({
+    queryKey: SONGS_KEY,
+    queryFn: () => musicService.getSongs({ isKaraoke: false, limit: 50 }),
+    staleTime: 2 * 60 * 1000,
+  });
+
+export const useKaraokeSongs = () =>
+  useQuery({
+    queryKey: KARAOKE_KEY,
+    queryFn: () => musicService.getSongs({ isKaraoke: true, limit: 50 }),
+    staleTime: 2 * 60 * 1000,
+  });
+
+export const useUploadSong = (isKaraoke: boolean) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      file,
+      meta,
+    }: {
+      file: File;
+      meta: { title: string; musicArtistId?: string };
+    }) =>
+      musicService.uploadSong(file, {
+        title: meta.title,
+        isKaraoke,
+        musicArtistId: meta.musicArtistId,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: isKaraoke ? KARAOKE_KEY : SONGS_KEY,
+      });
+    },
+  });
+};
+
+export const useDeleteSong = (isKaraoke: boolean) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => musicService.deleteSong(id),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: isKaraoke ? KARAOKE_KEY : SONGS_KEY,
+      });
+    },
+  });
+};
+
+export const useArtists = () =>
+  useQuery({
+    queryKey: ["artists"],
+    queryFn: musicService.getArtists,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/modules/communities/hooks/useCommunities.ts
+++ b/modules/communities/hooks/useCommunities.ts
@@ -59,9 +59,14 @@ export const useUpdateCommunitiesCategory = (options?: {
     }) => {
       // TODO: re-add color to payload once backend Joi schema is updated
       // Backend fix needed in: chumme-api/src/controllers/chumme-category.controller.ts
-      const res = await api.put(`/api/v1/chumme-categories/${params.id}`, {
-        name: params.name,
-      });
+      const payload: Record<string, unknown> = { name: params.name };
+      if (params.color) {
+        payload.colorSet = { primary: params.color };
+      }
+      const res = await api.put(
+        `/api/v1/chumme-categories/${params.id}`,
+        payload,
+      );
       if (!res.ok)
         throw new Error(
           (res.data as { message?: string })?.message || "Update failed",
@@ -103,9 +108,14 @@ export const useUpdateSubCategory = (options?: { onSuccess?: () => void }) => {
     }) => {
       // TODO: re-add color to payload once backend Joi schema is updated
       // Backend fix needed in: chumme-api/src/controllers/chumme-category.controller.ts
-      const res = await api.put(`/api/v1/chumme-subcategories/${params.id}`, {
-        name: params.name,
-      });
+      const payload: Record<string, unknown> = { name: params.name };
+      if (params.color) {
+        payload.colorSet = { primary: params.color };
+      }
+      const res = await api.put(
+        `/api/v1/chumme-subcategories/${params.id}`,
+        payload,
+      );
       if (!res.ok)
         throw new Error(
           (res.data as { message?: string })?.message || "Update failed",

--- a/modules/community/components/CommunityControlCenter.tsx
+++ b/modules/community/components/CommunityControlCenter.tsx
@@ -5,7 +5,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   Plus,
   X,
-  MapPin,
   Grid3x3,
   Activity,
   TrendingUp,
@@ -54,7 +53,7 @@ const getColorForId = (id: string, index: number) => {
   return PRESET_COLORS[index % PRESET_COLORS.length];
 };
 
-type TabId = "countries" | "categories" | "analytics" | "moderation";
+type TabId = "categories" | "subcategories" | "analytics" | "moderation";
 type ModalType = "country" | "category" | "community";
 
 interface CommunityControlCenterProps {
@@ -87,13 +86,16 @@ export const CommunityControlCenter = ({
     targetParentName: "",
   });
 
-  const [activeTab, setActiveTab] = useState<TabId>("countries");
+  const [activeTab, setActiveTab] = useState<TabId>("categories");
   const [showModal, setShowModal] = useState(false);
   const [modalType, setModalType] = useState<ModalType>("country");
   const [isEdit, setIsEdit] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCountryId, setSelectedCountryId] = useState<string>("");
+  const [colorOverrides, setColorOverrides] = useState<Record<string, string>>(
+    {},
+  );
 
   const resetForm = useCallback(() => {
     setFormData({
@@ -134,6 +136,7 @@ export const CommunityControlCenter = ({
 
   const onMutationSuccess = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: communitiesKeys.all });
+    setColorOverrides({});
     setShowModal(false);
     resetForm();
   }, [queryClient, resetForm]);
@@ -182,7 +185,9 @@ export const CommunityControlCenter = ({
       setIsEdit(true);
       setEditingId(item.id);
       const color =
-        item.color ?? item.chummeVisualDesign?.colorSet?.primary ?? "#D3427B";
+        item.color ??
+        (item.chummeVisualDesign?.colorSet as any)?.primary ??
+        "#D3427B";
       setFormData({
         name: item.name,
         color: color,
@@ -206,9 +211,9 @@ export const CommunityControlCenter = ({
           chummeTrait: "COMMUNITIES",
         },
         {
-          onSuccess: () => showSuccess("Country created successfully"),
+          onSuccess: () => showSuccess("Category created successfully"),
           onError: (err: { message?: string }) =>
-            showError(err?.message || "Failed to create country"),
+            showError(err?.message || "Failed to create category"),
         },
       );
     } else if (modalType === "category") {
@@ -243,11 +248,23 @@ export const CommunityControlCenter = ({
   const handleUpdate = useCallback(() => {
     if (!formData.name.trim() || !editingId) return;
 
-    const payload = { id: editingId, name: formData.name };
+    // Optimistic update — show color change instantly
+    if (editingId && formData.color) {
+      setColorOverrides((prev) => ({
+        ...prev,
+        [editingId]: formData.color,
+      }));
+    }
+
+    const payload = {
+      id: editingId,
+      name: formData.name,
+      color: formData.color,
+    };
 
     if (modalType === "country") {
       updateCountry(payload, {
-        onSuccess: () => showSuccess("Country updated successfully"),
+        onSuccess: () => showSuccess("Category updated successfully"),
         onError: (err: { message?: string }) =>
           showError(err?.message || "Update failed"),
       });
@@ -260,6 +277,7 @@ export const CommunityControlCenter = ({
     }
   }, [
     editingId,
+    formData.color,
     formData.name,
     modalType,
     showError,
@@ -287,6 +305,7 @@ export const CommunityControlCenter = ({
         name: c.name,
         count: c.populationCount || 0,
         color:
+          colorOverrides[c.id] ||
           c.color ||
           c.chummeVisualDesign?.colorSet?.primary ||
           getColorForId(c.id, i),
@@ -294,7 +313,7 @@ export const CommunityControlCenter = ({
         onClick: () => openEdit("country", c),
         chummeVisualDesign: c.chummeVisualDesign ?? null,
       }));
-  }, [countries, searchQuery, openEdit]);
+  }, [countries, searchQuery, openEdit, colorOverrides]);
 
   const categoryBubbles = useMemo(() => {
     return subcategories
@@ -304,6 +323,7 @@ export const CommunityControlCenter = ({
         name: s.name,
         count: s.populationCount || 0,
         color:
+          colorOverrides[s.id] ||
           s.color ||
           s.chummeVisualDesign?.colorSet?.primary ||
           getColorForId(s.id, i + 5),
@@ -311,7 +331,7 @@ export const CommunityControlCenter = ({
         onClick: () => openEdit("category", s),
         chummeVisualDesign: s.chummeVisualDesign ?? null,
       }));
-  }, [subcategories, searchQuery, openEdit]);
+  }, [subcategories, searchQuery, openEdit, colorOverrides]);
 
   // ─── Styles ─────────────────────────────────────────────────────────────────
 
@@ -326,8 +346,8 @@ export const CommunityControlCenter = ({
     label: string;
     icon: React.ComponentType<{ className?: string }>;
   }[] = [
-    { id: "countries", label: "Countries", icon: MapPin },
     { id: "categories", label: "Categories", icon: Grid3x3 },
+    { id: "subcategories", label: "Sub Categories", icon: Grid3x3 },
     { id: "analytics", label: "Analytics", icon: TrendingUp },
     { id: "moderation", label: "Moderation", icon: AlertTriangle },
   ];
@@ -351,10 +371,10 @@ export const CommunityControlCenter = ({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-10">
         {[
           {
-            label: "Countries",
+            label: "Categories",
             value: countries.length,
             sub: "Live from backend",
-            icon: MapPin,
+            icon: Grid3x3,
             color: "#A53860",
           },
           {
@@ -416,7 +436,10 @@ export const CommunityControlCenter = ({
         {tabs.map((tab) => (
           <button
             key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => {
+              setActiveTab(tab.id);
+              setSearchQuery("");
+            }}
             className={`px-6 py-3 rounded-xl text-sm font-bold transition-all whitespace-nowrap flex items-center gap-2 ${
               activeTab === tab.id
                 ? "bg-linear-to-r from-[#A53860] to-[#670D2F] text-white shadow-xl shadow-[#A53860]/20"
@@ -432,10 +455,10 @@ export const CommunityControlCenter = ({
       </div>
 
       <AnimatePresence mode="wait">
-        {/* COUNTRIES TAB */}
-        {activeTab === "countries" && (
+        {/* CATEGORIES TAB — shows top-level country/category bubbles */}
+        {activeTab === "categories" && (
           <motion.div
-            key="countries"
+            key="categories"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
@@ -445,7 +468,7 @@ export const CommunityControlCenter = ({
                 onClick={() => openCreate("country")}
                 className="h-12 px-8 bg-linear-to-r from-[#A53860] to-[#670D2F] text-white rounded-xl font-bold flex items-center justify-center gap-2 hover:opacity-90 shadow-lg transition-all active:scale-95"
               >
-                <Plus className="w-5 h-5" /> Add Country
+                <Plus className="w-5 h-5" /> Add Category
               </button>
               <div className="relative flex-1">
                 <Search
@@ -453,7 +476,7 @@ export const CommunityControlCenter = ({
                 />
                 <input
                   type="text"
-                  placeholder="Search countries..."
+                  placeholder="Search categories..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className={`${inputClass(isDark)} pl-12 h-12`}
@@ -482,12 +505,12 @@ export const CommunityControlCenter = ({
                   <p
                     className={`text-xl font-bold ${isDark ? "text-gray-300" : "text-gray-700"}`}
                   >
-                    No countries found
+                    No categories yet
                   </p>
                   <p
                     className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}
                   >
-                    Start by adding a new region
+                    Click &quot;Add Category&quot; to get started
                   </p>
                 </div>
               )}
@@ -495,25 +518,26 @@ export const CommunityControlCenter = ({
           </motion.div>
         )}
 
-        {/* CATEGORIES TAB */}
-        {activeTab === "categories" && (
+        {/* SUBCATEGORIES TAB */}
+        {activeTab === "subcategories" && (
           <motion.div
-            key="categories"
+            key="subcategories"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
           >
+            {/* Category selector pills */}
             <div className="flex gap-2 overflow-x-auto mb-6 pb-2 scrollbar-hide">
               {countries.map((c) => (
                 <button
                   key={c.id}
                   onClick={() => setSelectedCountryId(c.id)}
-                  className={`px-4 py-2 rounded-lg text-xs font-bold transition-all whitespace-nowrap border-2 ${
+                  className={`px-4 py-2 rounded-xl text-xs font-semibold transition-all whitespace-nowrap border-2 ${
                     selectedCountryId === c.id
                       ? "border-[#A53860] bg-[#A53860]/10 text-[#A53860]"
                       : isDark
-                        ? "border-gray-700 text-gray-500 hover:border-gray-600"
-                        : "border-gray-200 text-gray-500 hover:border-gray-300"
+                        ? "border-gray-700 text-gray-500 hover:border-gray-600 hover:text-gray-300"
+                        : "border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700"
                   }`}
                 >
                   {c.name}
@@ -521,13 +545,14 @@ export const CommunityControlCenter = ({
               ))}
             </div>
 
+            {/* Add Subcategory + Search row */}
             <div className="flex flex-col md:flex-row gap-4 mb-6">
               <button
                 onClick={() => openCreate("category")}
                 disabled={countries.length === 0}
                 className="h-12 px-8 bg-linear-to-r from-[#A53860] to-[#670D2F] text-white rounded-xl font-bold flex items-center justify-center gap-2 hover:opacity-90 shadow-lg transition-all active:scale-95 disabled:opacity-50"
               >
-                <Plus className="w-5 h-5" /> Add Category
+                <Plus className="w-5 h-5" /> Add Subcategory
               </button>
               <div className="relative flex-1">
                 <Search
@@ -535,7 +560,7 @@ export const CommunityControlCenter = ({
                 />
                 <input
                   type="text"
-                  placeholder="Search in categories..."
+                  placeholder="Search subcategories..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className={`${inputClass(isDark)} pl-12 h-12`}
@@ -543,6 +568,7 @@ export const CommunityControlCenter = ({
               </div>
             </div>
 
+            {/* Bubble canvas for subcategories */}
             <div
               className={`${cardBase} p-6 min-h-[500px] h-[600px] relative overflow-hidden shadow-2xl`}
             >
@@ -556,22 +582,16 @@ export const CommunityControlCenter = ({
                   isDark={isDark}
                 />
               )}
-              {subcategories.length === 0 && !loadingSub && (
+              {!loadingSub && subcategories.length === 0 && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center">
-                  <div className="text-7xl mb-4" role="img" aria-label="Target">
-                    🎯
-                  </div>
-                  <p
-                    className={`text-xl font-bold ${isDark ? "text-gray-300" : "text-gray-700"}`}
-                  >
-                    No categories yet
+                  <div className="text-7xl mb-4">🎯</div>
+                  <p className={`text-xl font-bold ${isDark ? "text-gray-300" : "text-gray-700"}`}>
+                    No subcategories yet
                   </p>
-                  <p
-                    className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}
-                  >
-                    {isEdit
-                      ? "Update existing country/category"
-                      : "Configure a new community for the region"}
+                  <p className={`text-sm ${isDark ? "text-gray-500" : "text-gray-400"}`}>
+                    {countries.length === 0
+                      ? "Add a category first before adding subcategories"
+                      : "Click \"Add Subcategory\" to get started"}
                   </p>
                 </div>
               )}
@@ -758,8 +778,13 @@ export const CommunityControlCenter = ({
                   <h3
                     className={`text-2xl font-black ${isDark ? "text-white" : "text-gray-900"}`}
                   >
-                    {isEdit ? "Manage" : "Initialize"}{" "}
-                    {modalType === "country" ? "Country" : "Category"}
+                    {isEdit
+                      ? modalType === "category"
+                        ? "Edit Subcategory"
+                        : "Edit Category"
+                      : modalType === "category"
+                        ? "Add Subcategory"
+                        : "Add Category"}
                   </h3>
                   <p className="text-sm text-gray-400">
                     Chumme Administrative Panel
@@ -780,7 +805,7 @@ export const CommunityControlCenter = ({
                       <label
                         className={`block text-xs font-black uppercase tracking-widest mb-2 ${isDark ? "text-gray-500" : "text-gray-400"}`}
                       >
-                        Official Name
+                        Category Name
                       </label>
                       <input
                         type="text"
@@ -811,7 +836,7 @@ export const CommunityControlCenter = ({
                       <label
                         className={`block text-xs font-black uppercase tracking-widest mb-2 ${isDark ? "text-gray-500" : "text-gray-400"}`}
                       >
-                        Category Label
+                        Category Name
                       </label>
                       <input
                         type="text"
@@ -830,7 +855,7 @@ export const CommunityControlCenter = ({
                       <label
                         className={`block text-xs font-black uppercase tracking-widest mb-2 ${isDark ? "text-gray-500" : "text-gray-400"}`}
                       >
-                        Primary Country
+                        Parent Category
                       </label>
                       <select
                         value={formData.targetParentName}
@@ -842,7 +867,7 @@ export const CommunityControlCenter = ({
                         }
                         className={inputClass(isDark)}
                       >
-                        <option value="">Select Target Region</option>
+                        <option value="">Select Parent Category</option>
                         {countries.map((c) => (
                           <option key={c.id} value={c.name}>
                             {c.name}

--- a/modules/dashboard/components/DashboardLayout.tsx
+++ b/modules/dashboard/components/DashboardLayout.tsx
@@ -31,8 +31,14 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
 
-  const { activeNav, setActiveNav, settingsExpanded, setSettingsExpanded } =
-    useDashboardStore();
+  const {
+    activeNav,
+    setActiveNav,
+    settingsExpanded,
+    setSettingsExpanded,
+    musicExpanded,
+    setMusicExpanded,
+  } = useDashboardStore();
 
   useEffect(() => {
     const currentNavItem = NAV_ITEMS.find((item) => item.href === pathname);
@@ -42,6 +48,15 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
       setActiveNav("Dashboard");
     } else if (pathname.includes("profile")) {
       setActiveNav("Profile");
+    } else if (pathname.includes("/dashboard/music")) {
+      setMusicExpanded(true);
+      if (pathname.includes("/karaoke")) {
+        setActiveNav("Karaoke");
+      } else if (pathname.includes("/song")) {
+        setActiveNav("Song");
+      } else {
+        setActiveNav("Music");
+      }
     } else if (pathname.includes("/dashboard/settings")) {
       if (pathname.endsWith("/roles")) {
         setActiveNav("Roles & Permissions");
@@ -98,6 +113,78 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
         <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
           {NAV_ITEMS.map((item) => {
             const active = activeNav === item.label;
+            const isMusic = item.label === "Music";
+            const isMusicActive =
+              activeNav === "Music" ||
+              activeNav === "Karaoke" ||
+              activeNav === "Song";
+
+            if (isMusic) {
+              return (
+                <div key={item.label}>
+                  <button
+                    onClick={() => {
+                      setMusicExpanded((prev) => !prev);
+                      setActiveNav("Music");
+                    }}
+                    className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all ${
+                      isMusicActive
+                        ? "bg-linear-to-r from-[#A53860] to-[#670D2F] text-white shadow-md font-semibold"
+                        : isDark
+                          ? "text-gray-300 hover:bg-gray-800"
+                          : "text-gray-600 hover:bg-gray-100"
+                    }`}
+                  >
+                    <item.icon className="w-5 h-5 shrink-0" />
+                    <span className="font-medium flex-1 text-left text-sm">
+                      Music
+                    </span>
+                    <motion.div
+                      animate={{ rotate: musicExpanded ? 180 : 0 }}
+                      transition={{ duration: 0.2, ease: "easeInOut" }}
+                    >
+                      <ChevronDown className="w-4 h-4" />
+                    </motion.div>
+                  </button>
+
+                  <AnimatePresence>
+                    {musicExpanded && item.children && (
+                      <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: "easeInOut" }}
+                        className="overflow-hidden"
+                      >
+                        <div className="mt-1 ml-9 space-y-1">
+                          {item.children.map((child) => (
+                            <button
+                              key={child.label}
+                              onClick={() => {
+                                setActiveNav(child.label);
+                                router.push(child.href);
+                              }}
+                              className={`w-full text-left px-4 py-2.5 rounded-lg text-xs transition-all ${
+                                activeNav === child.label
+                                  ? "text-[#A53860] bg-[#A53860]/10 font-bold"
+                                  : isDark
+                                    ? "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                                    : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                              }`}
+                            >
+                              <div className="flex items-center gap-2">
+                                <child.icon className="w-3.5 h-3.5 shrink-0" />
+                                {child.label}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              );
+            }
 
             return (
               <div key={item.label}>
@@ -118,24 +205,22 @@ export const DashboardLayout = ({ children }: DashboardLayoutProps) => {
 
                 {item.children && active && (
                   <div className="pl-7 mt-1 space-y-1">
-                    {item.children.map((child) => {
-                      return (
-                        <Link
-                          key={child.label}
-                          href={child.href}
-                          className={`flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium transition-all ${
-                            pathname === child.href
-                              ? "text-[#A53860] bg-[#A53860]/10"
-                              : isDark
-                                ? "text-gray-400 hover:text-gray-200"
-                                : "text-gray-500 hover:text-gray-900"
-                          }`}
-                        >
-                          <child.icon className="w-3.5 h-3.5 shrink-0" />
-                          {child.label}
-                        </Link>
-                      );
-                    })}
+                    {item.children.map((child) => (
+                      <Link
+                        key={child.label}
+                        href={child.href}
+                        className={`flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium transition-all ${
+                          pathname === child.href
+                            ? "text-[#A53860] bg-[#A53860]/10"
+                            : isDark
+                              ? "text-gray-400 hover:text-gray-200"
+                              : "text-gray-500 hover:text-gray-900"
+                        }`}
+                      >
+                        <child.icon className="w-3.5 h-3.5 shrink-0" />
+                        {child.label}
+                      </Link>
+                    ))}
                   </div>
                 )}
               </div>

--- a/modules/dashboard/constants/nav-items.ts
+++ b/modules/dashboard/constants/nav-items.ts
@@ -8,6 +8,9 @@ import {
   User,
   Activity,
   LayoutGrid,
+  Headphones,
+  Mic2,
+  Music2,
 } from "lucide-react";
 import type React from "react";
 
@@ -39,6 +42,15 @@ export const NAV_ITEMS: NavItem[] = [
     children: [
       { label: "Communities", href: "/dashboard/communities", icon: Users },
       { label: "Entertainment", href: "/dashboard/entertainment", icon: Star },
+    ],
+  },
+  {
+    label: "Music",
+    href: "#",
+    icon: Headphones,
+    children: [
+      { label: "Karaoke", href: "/dashboard/music/karaoke", icon: Mic2 },
+      { label: "Song", href: "/dashboard/music/song", icon: Music2 },
     ],
   },
   {

--- a/modules/dashboard/store/useDashboardStore.ts
+++ b/modules/dashboard/store/useDashboardStore.ts
@@ -7,6 +7,8 @@ interface DashboardState {
   setSettingsExpanded: (
     expanded: boolean | ((prev: boolean) => boolean),
   ) => void;
+  musicExpanded: boolean;
+  setMusicExpanded: (val: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 export const useDashboardStore = create<DashboardState>((set) => ({
@@ -19,5 +21,10 @@ export const useDashboardStore = create<DashboardState>((set) => ({
         typeof expanded === "function"
           ? expanded(state.settingsExpanded)
           : expanded,
+    })),
+  musicExpanded: false,
+  setMusicExpanded: (val) =>
+    set((state) => ({
+      musicExpanded: typeof val === "function" ? val(state.musicExpanded) : val,
     })),
 }));


### PR DESCRIPTION
Add server/API client for music management and new dashboard routes, and refactor Music and Karaoke pages to use data hooks and real APIs.

Key changes:
- Add app/dashboard/music/song and karaoke client route wrappers (theme-aware).
- New modules/collaboration/api/music.service.ts: typed music API client (list, artists, upload, delete).
- Integrate data hooks (useMusic) into KaraokePage and MusicPage: fetch songs/artists, loading/error/empty states, refresh button.
- Big UI refactor for KaraokePage and MusicPage: modernized cards/tables, add-song modals with file validation, upload/delete flows, improved dark/light styling and animations.

These changes replace mocked data with API-driven flows and add upload/delete UX for songs and karaoke assets.